### PR TITLE
fix: return err when addPartitionSetGPT fails

### DIFF
--- a/linux/disk.go
+++ b/linux/disk.go
@@ -655,7 +655,7 @@ func addPartitionSet(d disko.Disk, pSet disko.PartitionSet) error {
 			}
 		} else {
 			if err := addPartitionSetGPT(fp, d, pSet); err != nil {
-				return nil
+				return err
 			}
 		}
 


### PR DESCRIPTION
Fix the thinko which returns nil when addPartitioSetGPT fails by returning the err instead of nil.